### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,24 +6,24 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-HaLakeM5StackLibrary KEYWORD1
+HaLakeM5StackLibrary	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
 begin	KEYWORD2
-begin KEYWORD2
-connectWifi KEYWORD2
+begin	KEYWORD2
+connectWifi	KEYWORD2
 
-webServer_addService KEYWORD2
-webServer_setNotFound KEYWORD2
-webServer_open KEYWORD2
-webServer_requestHandle KEYWORD2
+webServer_addService	KEYWORD2
+webServer_setNotFound	KEYWORD2
+webServer_open	KEYWORD2
+webServer_requestHandle	KEYWORD2
 
-SPIFFS_readFile KEYWORD2
-SPIFFS_writeFile KEYWORD2
-SPIFFS_removeFile KEYWORD2
+SPIFFS_readFile	KEYWORD2
+SPIFFS_writeFile	KEYWORD2
+SPIFFS_removeFile	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords